### PR TITLE
fix mobile nav stacking issue

### DIFF
--- a/themes/hugo-serif-theme/assets/scss/components/_main-menu-mobile.scss
+++ b/themes/hugo-serif-theme/assets/scss/components/_main-menu-mobile.scss
@@ -23,18 +23,23 @@
       animation-delay: 0.35s;
       &:nth-of-type(2) {
         animation-delay: 0.4s;
+        z-index: 25;
       }
       &:nth-of-type(3) {
         animation-delay: 0.45s;
+        z-index: 24;
       }
       &:nth-of-type(4) {
         animation-delay: 0.5s;
+        z-index: 23;
       }
       &:nth-of-type(5) {
         animation-delay: 0.55s;
+        z-index: 22;
       }
       &:nth-of-type(6) {
         animation-delay: 0.6s;
+        z-index: 21;
       }
     }
   }


### PR DESCRIPTION
RE: https://twitter.com/jeremyrubin/status/1407119465087602691?s=21

The problem was due to stacking contexts in the document. You're using `opacity` when animating the `li` elements, which creates a new stacking context for each`li` automatically. Since the sub-menus are nested under the `li`s, the `z-index` value  on the menu `div`s become relative to the children of their parent `li`. This essentially makes the `z-index` of the sub-menu irrelevant. 

The solution is simple. You just have to apply incrementing `z-index`es to each `li` to force the sub-menu of the preceding `li` to have a higher value than subsequent `li`s. This increases the stacking of their children as well.

![image](https://user-images.githubusercontent.com/1356600/122862659-79f44380-d2ef-11eb-9778-fc69a1c2fa3d.png)


For a deep dive into `z-index` hell, check out https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context