### PR TITLE
suggestion: make mobile menu link styles consistent

### DIFF
--- a/themes/hugo-serif-theme/layouts/partials/main-menu-mobile.html
+++ b/themes/hugo-serif-theme/layouts/partials/main-menu-mobile.html
@@ -5,7 +5,7 @@
 
 			{{ if .HasChildren }}
 				<li class="menu-item-{{ .Name | lower }} dropdown show">
-					<a class="btn dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+					<a class="dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 							{{ .Pre }}
 							<span>{{ .Name }}</span>
 					</a>


### PR DESCRIPTION
I'm not sure if the mismatch styles of the dropdown links in the mobile menu were intended to be that way. If you would like all of the link styles to match, this is a simple fix. Feel free to nuke this PR if you want to keep them the way they are.

Before:
![image](https://user-images.githubusercontent.com/1356600/122863353-9d6bbe00-d2f0-11eb-98fa-29fb3acc0905.png)

After:
![image](https://user-images.githubusercontent.com/1356600/122863417-b4121500-d2f0-11eb-923b-51f6941f8eb6.png)
