### PR TITLE
fix: update nate affiliation on signals

### DIFF
--- a/data/devs.yaml
+++ b/data/devs.yaml
@@ -533,7 +533,7 @@
   Supports: "Yes"
   Highlight: false
   Link: "https://twitter.com/nk1tz/status/1484299975400079361"
-  Affiliations: "VP Engineering of Bull Bitcoin"
+  Affiliations: "Engineering at Unchained"
 - Name: "Hampus Sjöberg"
   Supports: "Yes"
   Highlight: false


### PR DESCRIPTION
Am now at Unchained.
Support has not changed.